### PR TITLE
Add JRebel Cloud/Remote support

### DIFF
--- a/.sti/bin/assemble
+++ b/.sti/bin/assemble
@@ -150,6 +150,41 @@ function ismgmtup() {
   return 1
 }
 
+function install_jrebel() {
+  local nullglobopt=$(shopt -p nullglob)
+  shopt -s nullglob
+  local found=false
+  for war in $1/*.war; do
+    if unzip -l "$war" WEB-INF/classes/rebel-remote.xml > /dev/null; then
+      echo "JRebel: rebel-remote.xml found in $war"
+      found=true
+    fi
+  done
+  eval $nullglobopt
+  
+  ! $found && return 1
+  
+  echo "JRebel: Fetching version index ..."
+  local line=$(curl -s https://dl.zeroturnaround.com/jrebel/index.yml | grep "^[0-9]" | sort -V -k 1,1 -t ":" -b | tail -1)
+  local parts=(${line//: / })
+  local version=${parts[0]}
+  local url=${parts[1]}
+  local jrzip=$(basename "$url")
+  echo "JRebel: Latest version is $version"
+  
+  pushd ${HOME} &> /dev/null
+  
+  echo "JRebel: Downloading $url ..."
+  curl -sO "$url"
+  
+  echo "JRebel: Extracting $jrzip ..."
+  unzip -qq "$jrzip"
+  rm "$jrzip"
+  
+  popd &> /dev/null
+  return 0
+}
+
 ADMIN=admin
 PASSWORD=passw0rd_
 
@@ -199,6 +234,10 @@ if [ -d $LOCAL_SOURCE_DIR/target ]; then
 fi
 if [ -d $LOCAL_SOURCE_DIR/deployments ]; then
   cp $LOCAL_SOURCE_DIR/deployments/*.war $DEPLOY_DIR >& /dev/null
+fi
+
+if [ -z "$DISABLE_JREBEL" -o "$DISABLE_JREBEL" = "false" ]; then
+  install_jrebel $DEPLOY_DIR
 fi
 
 if [ -d $LOCAL_SOURCE_DIR/cfg ]; then

--- a/wfbin/standalone.conf
+++ b/wfbin/standalone.conf
@@ -127,6 +127,14 @@ if [ -z "$JAVA_OPTS" ]; then
    fi
 fi
 
+if [ -d "${HOME}/jrebel" ]; then
+  libname=libjrebel32.so
+  if java -version 2>&1 | grep -q "64-Bit"; then
+    libname=libjrebel64.so
+  fi
+  JAVA_OPTS="-agentpath:${HOME}/jrebel/lib/${libname} -Drebel.remoting_plugin=true -Drebel.log=true -Drebel.cloud.platform=openshift/wildfly-8-centos ${JAVA_OPTS}"
+fi
+
 if [ -n "$JAVA_OPTS_EXT" ]; then
     JAVA_OPTS="$JAVA_OPTS $JAVA_OPTS_EXT"
 fi


### PR DESCRIPTION
When a JRebel Cloud/Remote enabled application (containing `rebel-remote.xml`) is being built, automatically download the latest JRebel version and enable it for the application server.